### PR TITLE
use explicit linebreaks

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,8 +54,8 @@ Webware (CS-4241)
 
 Term A -- 2017
 
-Location  
-Fuller Lower  
-M/R 12:00-1:50pm  
+Location<br>
+Fuller Lower<br>
+M/R 12:00-1:50pm
 
 New? [Check out init](/init/) to get started.


### PR DESCRIPTION
Instead of trailing spaces for newlines, something that could easily be overlooked or interpreted for a mistake, we can use explicit `<br>` elements